### PR TITLE
template attribute

### DIFF
--- a/cimi/src/sixsq/nuvla/auth/utils/db.clj
+++ b/cimi/src/sixsq/nuvla/auth/utils/db.clj
@@ -146,7 +146,7 @@
      :params       {:resource-name "user"}
      :route-params {:resource-name "user"}
      :user-roles   #{"ANON"}
-     :body         {:userTemplate user-resource}}))
+     :body         {:template user-resource}}))
 
 
 (defn user-param-create-request

--- a/cimi/src/sixsq/nuvla/auth/utils/db.clj
+++ b/cimi/src/sixsq/nuvla/auth/utils/db.clj
@@ -159,7 +159,7 @@
    :params       {:resource-name "user-param"}
    :route-params {:resource-name "user-param"}
    :user-roles   #{"USER"}
-   :body         {:userParamTemplate up-tmpl-exec/resource}})
+   :body         {:template up-tmpl-exec/resource}})
 
 
 (defn create-user-params!

--- a/cimi/src/sixsq/nuvla/server/resources/callback_create_session_github.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/callback_create_session_github.clj
@@ -21,7 +21,7 @@
 
 (defn validate-session
   [request session-id]
-  (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
+  (let [{:keys [server clientIP redirectURI] {:keys [href]} :template :as current-session} (sutils/retrieve-session-by-id session-id)
         {:keys [instance]} (crud/retrieve-by-id-as-admin href)
         [client-id client-secret] (gu/config-github-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]

--- a/cimi/src/sixsq/nuvla/server/resources/callback_create_session_mitreid.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/callback_create_session_mitreid.clj
@@ -24,7 +24,7 @@
 (defn validate-session
   [{{session-id :href} :targetResource callback-id :id :as callback-resource} {:keys [base-uri] :as request}]
 
-  (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
+  (let [{:keys [server clientIP redirectURI] {:keys [href]} :template :as current-session} (sutils/retrieve-session-by-id session-id)
         {:keys [instance]} (crud/retrieve-by-id-as-admin href)
         {:keys [clientID clientSecret publicKey tokenURL]} (oidc-utils/config-mitreid-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]

--- a/cimi/src/sixsq/nuvla/server/resources/callback_create_session_oidc.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/callback_create_session_oidc.clj
@@ -25,7 +25,7 @@
 (defn validate-session
   [{{session-id :href} :targetResource callback-id :id :as callback-resource} {:keys [base-uri] :as request}]
 
-  (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
+  (let [{:keys [server clientIP redirectURI] {:keys [href]} :template :as current-session} (sutils/retrieve-session-by-id session-id)
         {:keys [instance]} (crud/retrieve-by-id-as-admin href)
         {:keys [clientID clientSecret publicKey tokenURL]} (oidc-utils/config-oidc-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]

--- a/cimi/src/sixsq/nuvla/server/resources/common/utils.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/common/utils.clj
@@ -227,7 +227,7 @@
   "Allow form encoded data to be supplied for a session. This is required to
    support external authentication methods triggered via a 'submit' button in
    an HTML form. This takes the flat list of form parameters, keywordizes the
-   keys, and adds the parent :sessionTemplate key."
+   keys, and adds the parent :template key."
   [tpl form-data]
   {tpl (walk/keywordize-keys form-data)})
 

--- a/cimi/src/sixsq/nuvla/server/resources/configuration.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/configuration.clj
@@ -50,7 +50,7 @@
 ;;
 
 (defn dispatch-on-service [resource]
-  (get-in resource [:configurationTemplate :service]))
+  (get-in resource [:template :service]))
 
 (defmulti create-validate-subtype dispatch-on-service)
 
@@ -82,7 +82,7 @@
 (defmethod tpl->configuration :default
   [{:keys [href] :as resource}]
   (cond-> resource
-      href (assoc :configurationTemplate {:href href})
+      href (assoc :template {:href href})
       true (dissoc :href)
       true (assoc :resourceURI resource-uri)))
 
@@ -100,9 +100,9 @@
         body (-> body
                  (assoc :resourceURI create-uri)
                  (std-crud/resolve-hrefs idmap true)
-                 (update-in [:configurationTemplate] merge desc-attrs) ;; validate desc attrs
+                 (update-in [:template] merge desc-attrs) ;; validate desc attrs
                  (crud/validate)
-                 (:configurationTemplate)
+                 (:template)
                  (tpl->configuration))]
     (add-impl (assoc request :body (merge body desc-attrs)))))
 

--- a/cimi/src/sixsq/nuvla/server/resources/configuration_slipstream.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/configuration_slipstream.clj
@@ -30,8 +30,8 @@
 
 
 (def create-template
-  {:resourceURI           p/create-uri
-   :configurationTemplate {:href "configuration-template/slipstream"}})
+  {:resourceURI p/create-uri
+   :template    {:href "configuration-template/slipstream"}})
 
 
 ;;

--- a/cimi/src/sixsq/nuvla/server/resources/connector.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/connector.clj
@@ -62,7 +62,7 @@
 ;;
 
 (defn dispatch-on-cloud-service-type [resource]
-  (get-in resource [:connectorTemplate :cloudServiceType]))
+  (get-in resource [:template :cloudServiceType]))
 
 (defmulti create-validate-subtype dispatch-on-cloud-service-type)
 
@@ -97,7 +97,7 @@
       (dissoc :href)
       (assoc :resourceURI resource-uri
              :acl resource-acl)
-      (cond-> href (assoc :connectorTemplate {:href href}))))
+      (cond-> href (assoc :template {:href href}))))
 
 ;;
 ;; CRUD operations
@@ -113,7 +113,7 @@
                  (assoc :resourceURI create-uri)
                  (std-crud/resolve-hrefs idmap true)
                  (crud/validate)
-                 (:connectorTemplate)
+                 :template
                  (tpl->connector))]
     (add-impl (assoc request :body body))))
 

--- a/cimi/src/sixsq/nuvla/server/resources/credential.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/credential.clj
@@ -61,7 +61,7 @@ CredentialTemplate resource.
 ;;
 
 (defn dispatch-on-registration-method [resource]
-  (get-in resource [:credentialTemplate :type]))
+  (get-in resource [:template :type]))
 
 (defmulti create-validate-subtype dispatch-on-registration-method)
 
@@ -139,22 +139,22 @@ CredentialTemplate resource.
   [body idmap]
   (let [admin {:identity {:current         "internal",
                           :authentications {"internal" {:roles #{"ADMIN"}, :identity "internal"}}}}
-        href (get-in body [:credentialTemplate :connector])]
+        href (get-in body [:template :connector])]
     (std-crud/resolve-hrefs href admin))
   body)
 
 (defn resolve-hrefs
   [body idmap]
-  (let [connector-href (if (contains? (:credentialTemplate body) :connector)
-                         {:connector (get-in body [:credentialTemplate :connector])}
+  (let [connector-href (if (contains? (:template body) :connector)
+                         {:connector (get-in body [:template :connector])}
                          {})]                               ;; to put back the unexpanded href after
     (-> body
         (check-connector-exists idmap)
         ;; remove connector href (if any); regular user doesn't have rights to see them
-        (update-in [:credentialTemplate] dissoc :connector)
+        (update-in [:template] dissoc :connector)
         (std-crud/resolve-hrefs idmap)
         ;; put back unexpanded connector href
-        (update-in [:credentialTemplate] merge connector-href))))
+        (update-in [:template] merge connector-href))))
 
 ;; requires a CredentialTemplate to create new Credential
 (defmethod crud/add resource-name
@@ -164,11 +164,11 @@ CredentialTemplate resource.
         [create-resp {:keys [id] :as body}]
         (-> body
             (assoc :resourceURI create-uri)
-            (update-in [:credentialTemplate] dissoc :type)  ;; forces use of template reference
+            (update-in [:template] dissoc :type)  ;; forces use of template reference
             (resolve-hrefs idmap)
-            (update-in [:credentialTemplate] merge desc-attrs) ;; ensure desc attrs are validated
+            (update-in [:template] merge desc-attrs) ;; ensure desc attrs are validated
             crud/validate
-            :credentialTemplate
+            :template
             (tpl->credential request))]
     (-> request
         (assoc :id id :body (merge body desc-attrs))

--- a/cimi/src/sixsq/nuvla/server/resources/deployment.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/deployment.clj
@@ -73,15 +73,15 @@
 
 (defn retrieve-deployment-template
   [deployment idmap]
-  (let [deployment-tmpl-href (get-in deployment [:deploymentTemplate :href])
+  (let [deployment-tmpl-href (get-in deployment [:template :href])
         {:keys [body status]} (if (= deployment-tmpl-href deployment-template/generated-url)
                                 {:status 200
-                                 :body   (du/create-deployment-template (:deploymentTemplate deployment) idmap)}
+                                 :body   (du/create-deployment-template (:template deployment) idmap)}
                                 (crud/retrieve {:params   {:uuid          (u/document-id deployment-tmpl-href)
                                                            :resource-name deployment-template/resource-url}
                                                 :identity idmap}))]
     (if (= status 200)
-      (assoc deployment :deploymentTemplate (dissoc body :operations :acl :id :href))
+      (assoc deployment :template (dissoc body :operations :acl :id :href))
       (throw (ex-info "" body)))))
 
 
@@ -104,16 +104,16 @@
     (a/can-modify? {:acl collection-acl} request)
     (let [idmap (:identity request)
           desc-attrs (u/select-desc-keys body)
-          deployment-tmpl-href (get-in body [:deploymentTemplate :href] deployment-template/generated-url)
+          deployment-tmpl-href (get-in body [:template :href] deployment-template/generated-url)
           [api-key secret] (generate-api-key-secret request)
           deployment (-> body
-                         (assoc-in [:deploymentTemplate :href] deployment-tmpl-href)
+                         (assoc-in [:template :href] deployment-tmpl-href)
                          (assoc :resourceURI create-uri)
                          (retrieve-deployment-template idmap)
-                         (update-in [:deploymentTemplate] merge desc-attrs) ;; ensure desc attrs are validated
+                         (update-in [:template] merge desc-attrs) ;; ensure desc attrs are validated
                          crud/validate
-                         :deploymentTemplate
-                         (assoc-in [:deploymentTemplate :href] deployment-tmpl-href)
+                         :template
+                         (assoc-in [:template :href] deployment-tmpl-href)
                          (assoc :clientAPIKey {:href api-key, :secret secret})
                          (assoc :state "CREATED"))
           create-response (add-impl (assoc request :body deployment))

--- a/cimi/src/sixsq/nuvla/server/resources/deployment.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/deployment.clj
@@ -90,7 +90,7 @@
 (defn generate-api-key-secret
   [{:keys [identity] :as request}]
   (let [request-api-key {:params   {:resource-name credential/resource-url}
-                         :body     {:credentialTemplate {:href (str "credential-template/" cred-api-key/method)}}
+                         :body     {:template {:href (str "credential-template/" cred-api-key/method)}}
                          :identity identity}
         {{:keys [status resource-id secretKey] :as body} :body :as response} (crud/add request-api-key)]
     (if (= status 201)

--- a/cimi/src/sixsq/nuvla/server/resources/deployment_template.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/deployment_template.clj
@@ -105,4 +105,4 @@
 
 (defn initialize
   []
-  (std-crud/initialize resource-url ::dt/deploymentTemplate))
+  (std-crud/initialize resource-url ::dt/template))

--- a/cimi/src/sixsq/nuvla/server/resources/external_object_template_generic.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/external_object_template_generic.clj
@@ -41,7 +41,7 @@
   [resource]
   (create-validate-fn resource))
 
-(def validate-fn (u/create-spec-validation-fn ::eot-generic/externalObjectTemplate))
+(def validate-fn (u/create-spec-validation-fn ::eot-generic/template))
 (defmethod eot/validate-subtype-template objectType
   [resource]
   (validate-fn resource))

--- a/cimi/src/sixsq/nuvla/server/resources/external_object_template_public.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/external_object_template_public.clj
@@ -40,7 +40,7 @@
   [resource]
   (create-validate-fn resource))
 
-(def validate-fn (u/create-spec-validation-fn ::eot-public/externalObjectTemplate))
+(def validate-fn (u/create-spec-validation-fn ::eot-public/template))
 (defmethod eot/validate-subtype-template objectType
   [resource]
   (validate-fn resource))

--- a/cimi/src/sixsq/nuvla/server/resources/session.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/session.clj
@@ -35,7 +35,7 @@ must re-authenticate with the server when the token expires.
 > NOTE: To facilitate use of the API from browsers (i.e. javascript), the
 session resources also support request bodies with a media type of
 'application/x-www-form-urlencoded'. When using this media type, encode only
-the value of the 'sessionTemplate key in the example JSON forms.
+the value of the 'template key in the example JSON forms.
 
 > NOTE: The search feature of Session resources will only return the Session
 resource associated with your current session (or none at all if your are not
@@ -47,7 +47,7 @@ via the 'interna' (username and password) method.
 
 ```json
 {
-  \"sessionTemplate\" : {
+  \"template\" : {
                         \"href\" : \"session-template/internal\",
                         \"username\" : \"your-username\",
                         \"password\" : \"your-password\"
@@ -61,7 +61,7 @@ administrator may have chosen a different name.
 
 ```json
 {
-  \"sessionTemplate\" : {
+  \"template\" : {
                         \"href\" : \"session-template/api-key\",
                         \"key\" : \"your-api-key\",
                         \"secret\" : \"your-api-secret\"
@@ -144,7 +144,7 @@ session.
 ;;
 
 (defn dispatch-on-authn-method [resource]
-  (get-in resource [:sessionTemplate :method]))
+  (get-in resource [:template :method]))
 
 (defmulti create-validate-subtype dispatch-on-authn-method)
 
@@ -256,7 +256,7 @@ session.
 (defn convert-request-body
   [{:keys [body form-params headers] :as request}]
   (if (u/is-form? headers)
-    (u/convert-form :sessionTemplate form-params)
+    (u/convert-form :template form-params)
     body))
 
 
@@ -271,16 +271,16 @@ session.
           [cookie-header {:keys [id] :as body}] (-> body
                                                     (assoc :resourceURI create-uri)
                                                     (std-crud/resolve-hrefs idmap true)
-                                                    (update-in [:sessionTemplate] merge desc-attrs) ;; validate desc attrs
+                                                    (update-in [:template] merge desc-attrs) ;; validate desc attrs
                                                     (crud/validate)
-                                                    (:sessionTemplate)
+                                                    (:template)
                                                     (tpl->session request))]
       (-> request
           (assoc :id id :body (merge body desc-attrs))
           add-impl
           (merge cookie-header)))
     (catch Exception e
-      (let [redirectURI (-> request convert-request-body :sessionTemplate :redirectURI)
+      (let [redirectURI (-> request convert-request-body :template :redirectURI)
             {:keys [status] :as http-response} (ex-data e)]
         (if (and redirectURI (= 400 status))
           (throw (r/ex-redirect (str "invalid parameter values provided") nil redirectURI))

--- a/cimi/src/sixsq/nuvla/server/resources/session/utils.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/session/utils.clj
@@ -58,8 +58,8 @@
   (let [server (or (get headers "slipstream-ssl-server-name") (:slipstream-ssl-server-name headers))
         client-ip (or (get headers "x-real-ip") (:x-real-ip headers))]
     (crud/new-identifier
-      (cond-> {:method          authn-method
-               :sessionTemplate {:href href}}
+      (cond-> {:method   authn-method
+               :template {:href href}}
               username (assoc :username username)
               server (assoc :server server)
               client-ip (assoc :clientIP client-ip)

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template.cljc
@@ -73,10 +73,10 @@
              :json-schema/sensitive false)))
 
 
-(s/def ::configurationTemplate
+(s/def ::template
   (-> (st/spec (su/only-keys-maps {:req-un [::href]}))
-      (assoc :name "configurationTemplate"
-             :json-schema/name "configurationTemplate"
+      (assoc :name "template"
+             :json-schema/name "template"
              :json-schema/namespace common-ns/slipstream-namespace
              :json-schema/uri common-ns/slipstream-uri
              :json-schema/type "map"
@@ -85,7 +85,7 @@
              :json-schema/mutable true
              :json-schema/consumerWritable true
 
-             :json-schema/displayName "configurationTemplate"
+             :json-schema/displayName "template"
              :json-schema/description "reference to the configuration template used"
              :json-schema/help "reference to the configuration template used"
              :json-schema/group "body"
@@ -101,7 +101,7 @@
 ;;
 
 (def configuration-template-keys-spec {:req-un [::service]
-                                       :opt-un [::instance ::configurationTemplate]})
+                                       :opt-un [::instance ::template]})
 
 (def resource-keys-spec
   (su/merge-keys-specs [c/common-attrs configuration-template-keys-spec]))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_github.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_github.cljc
@@ -70,11 +70,10 @@
                      configuration-template-keys-spec-req))
 
 ;; Defines the contents of the github authentication template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :configurationTemplate here.
-(s/def ::configurationTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      configuration-template-keys-spec-create))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::configurationTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_mitreid.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_mitreid.cljc
@@ -140,17 +140,16 @@
 (def configuration-template-keys-spec-create
   {:req-un [::ps/instance ::clientID ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userProfileURL]})
 
-;; Defines the contents of the Mi authentication ConfigurationTemplate resource itself.
+;; Defines the contents of the MITREid authentication ConfigurationTemplate resource itself.
 (s/def ::schema
   (su/only-keys-maps ps/resource-keys-spec
                      configuration-template-keys-spec-req))
 
 ;; Defines the contents of the MitreId authentication template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :configurationTemplate here.
-(s/def ::configurationTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      configuration-template-keys-spec-create))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::configurationTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_mitreid_token.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_mitreid_token.cljc
@@ -26,12 +26,11 @@
 
 
 ;; Defines the contents of the OIDC authentication template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :configurationTemplate here.
-(s/def ::configurationTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      configuration-template-keys-spec-create))
 
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::configurationTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_oidc.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_session_oidc.cljc
@@ -127,11 +127,10 @@
                      configuration-template-keys-spec-req))
 
 ;; Defines the contents of the OIDC authentication template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :configurationTemplate here.
-(s/def ::configurationTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      configuration-template-keys-spec-create))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::configurationTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_slipstream.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/configuration_template_slipstream.cljc
@@ -90,11 +90,10 @@
                      configuration-template-keys-spec-req))
 
 ;; Defines the contents of the slipstream template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :configurationTemplate here.
-(s/def ::configurationTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      configuration-template-keys-spec-opt))
 
 (s/def ::slipstream-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [::configurationTemplate]}))
+                     {:opt-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/connector_template.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/connector_template.cljc
@@ -276,7 +276,7 @@
 (s/def ::href (s/and string? #(re-matches connector-template-regex %)))
 
 
-(s/def ::connectorTemplate (su/only-keys :req-un [::href]))
+(s/def ::template (su/only-keys :req-un [::href]))
 
 ;;
 ;; Keys specifications for ConnectorTemplate resources.
@@ -289,7 +289,7 @@
                                             ::orchestratorImageid
                                             ::quotaVm
                                             ::maxIaasWorkers]
-                                   :opt-un [::connectorTemplate]})
+                                   :opt-un [::template]})
 
 (def resource-keys-spec
   (su/merge-keys-specs [c/common-attrs connector-template-keys-spec]))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/credential_api_key.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/credential_api_key.cljc
@@ -4,7 +4,7 @@
     [sixsq.nuvla.server.resources.spec.core :as cimi-core]
     [sixsq.nuvla.server.resources.spec.credential :as cred]
     [sixsq.nuvla.server.resources.spec.credential-template :as ps]
-    [sixsq.nuvla.server.resources.spec.credential-template-api-key]
+    [sixsq.nuvla.server.resources.spec.credential-template-api-key :as api-key]
     [sixsq.nuvla.server.util.spec :as su]))
 
 (s/def ::expiry ::cimi-core/timestamp)
@@ -33,4 +33,4 @@
 ;; multiple methods to create an ssh public key, so multiple schemas
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::ps/credentialTemplate]}))
+                     {:req-un [::api-key/template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_api_key.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_api_key.cljc
@@ -40,11 +40,10 @@
                      credential-template-keys-spec))
 
 ;; Defines the contents of the api-key template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :credentialTemplate here.
-(s/def ::credentialTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      credential-template-create-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::credentialTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_ssh_key_pair.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_ssh_key_pair.cljc
@@ -63,11 +63,10 @@
                      credential-template-keys-spec))
 
 ;; Defines the contents of the ssh-key-pair template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :credentialTemplate here.
-(s/def ::credentialTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      credential-template-create-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::credentialTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_ssh_public_key.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/credential_template_ssh_public_key.cljc
@@ -42,11 +42,10 @@
                      credential-template-keys-spec))
 
 ;; Defines the contents of the ssh-public-key template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :credentialTemplate here.
-(s/def ::credentialTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      credential-template-create-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::credentialTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/deployment.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/deployment.cljc
@@ -135,7 +135,7 @@
              :json-schema/sensitive false)))
 
 
-(s/def ::deploymentTemplate ::cimi-common/resource-link)
+(s/def ::template ::cimi-common/resource-link)
 
 
 (def ^:const external-object-id-regex #"^external-object/[a-z0-9]+(-[a-z0-9]+)*(_\d+)?$")
@@ -203,7 +203,7 @@
                         deployment-template/deployment-template-keys-spec
                         {:req-un [::state
                                   ::clientAPIKey]
-                         :opt-un [::deploymentTemplate
+                         :opt-un [::template
                                   ::sshPublicKeys
                                   ::externalObjects
                                   ::serviceOffers]}]))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/deployment_template.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/deployment_template.cljc
@@ -34,11 +34,10 @@
                                deployment-template-keys-spec))
 
 ;; Defines the contents of the generic template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :deploymentTemplate here.
-(s/def ::deploymentTemplate
+(s/def ::template
   (su/only-keys-maps cimi-common/template-attrs
                      deployment-template-keys-spec))
 
 (s/def ::deployment-template-create
   (su/only-keys-maps cimi-common/create-attrs
-                     {:req-un [::deploymentTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/external_object_template_generic.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/external_object_template_generic.cljc
@@ -11,11 +11,10 @@
   (u/remove-req eo/common-external-object-attrs #{::eo/state}))
 
 ;; Defines the contents of the generic template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :externalObjectTemplate here.
-(s/def ::externalObjectTemplate
+(s/def ::template
   (su/only-keys-maps c/template-attrs
                      template-resource-keys-spec))
 
 (s/def ::external-object-create
   (su/only-keys-maps c/create-attrs
-                     {:req-un [::externalObjectTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/external_object_template_public.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/external_object_template_public.cljc
@@ -10,11 +10,10 @@
   (u/remove-req eo/common-external-object-attrs #{::eo/state}))
 
 ;; Defines the contents of the public template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :externalObjectTemplate here.
-(s/def ::externalObjectTemplate
+(s/def ::template
   (su/only-keys-maps c/template-attrs
                      template-resource-keys-spec))
 
 (s/def ::external-object-create
   (su/only-keys-maps c/create-attrs
-                     {:req-un [::externalObjectTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session.cljc
@@ -10,9 +10,9 @@
 (s/def ::method ::session-tpl/method)
 
 ;; reference to the session template that was used to create the session
-(s/def ::sessionTemplate (s/merge
-                           (s/keys :req-un [::session-tpl/href])
-                           (s/map-of #{:href} any?)))
+(s/def ::template (s/merge
+                    (s/keys :req-un [::session-tpl/href])
+                    (s/map-of #{:href} any?)))
 
 ;; expiration time of the cookie
 (s/def ::expiry ::cimi-core/timestamp)
@@ -29,5 +29,5 @@
 
 (s/def ::session
   (su/only-keys-maps c/common-attrs
-                     {:req-un [::method ::sessionTemplate ::expiry]
+                     {:req-un [::method ::template ::expiry]
                       :opt-un [::username ::roles ::server ::clientIP ::hints/redirectURI]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_api_key.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_api_key.cljc
@@ -60,11 +60,10 @@
                      session-template-keys-spec))
 
 ;; Defines the contents of the api-key template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      session-template-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_github.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_github.cljc
@@ -12,10 +12,9 @@
   (su/only-keys-maps ps/resource-keys-spec))
 
 ;; Defines the contents of the github template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_internal.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_internal.cljc
@@ -60,11 +60,10 @@
                      session-template-keys-spec-req))
 
 ;; Defines the contents of the internal template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      session-template-keys-spec-req))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_mitreid.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_mitreid.cljc
@@ -10,10 +10,9 @@
   (su/only-keys-maps ps/resource-keys-spec))
 
 ;; Defines the contents of the MITREid template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_mitreid_token.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_mitreid_token.cljc
@@ -38,11 +38,10 @@
                      session-template-keys-spec))
 
 ;; Defines the contents of the oidc-token template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      session-template-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/session_template_oidc.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/session_template_oidc.cljc
@@ -10,10 +10,9 @@
   (su/only-keys-maps ps/resource-keys-spec))
 
 ;; Defines the contents of the oidc template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
-(s/def ::sessionTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::sessionTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_params_template_exec.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_params_template_exec.cljc
@@ -32,12 +32,11 @@
                      user-params-template-exec-keys-spec))
 
 ;; Defines the contents of the auto template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userParamTemplate here.
-(s/def :cimi.user-params-template.exec/userParamTemplate
+(s/def :cimi.user-params-template.exec/template
   (su/only-keys-maps ps/template-keys-spec
                      user-params-template-exec-keys-spec))
 
 (s/def :cimi/user-params-template.exec-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [:cimi.user-params-template.exec/userParamTemplate]}))
+                     {:opt-un [:cimi.user-params-template.exec/template]}))
 

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_params_template_exec.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_params_template_exec.cljc
@@ -32,7 +32,7 @@
                      user-params-template-exec-keys-spec))
 
 ;; Defines the contents of the auto template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
+;; NOTE: The name must match the key defined by the resource, :userParamTemplate here.
 (s/def :cimi.user-params-template.exec/userParamTemplate
   (su/only-keys-maps ps/template-keys-spec
                      user-params-template-exec-keys-spec))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_template_direct.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_template_direct.cljc
@@ -32,11 +32,10 @@
                      user-template-keys-spec-req))
 
 ;; Defines the contents of the direct template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
-(s/def ::userTemplate
+(s/def ::template
   (su/only-keys-maps user-template/template-keys-spec
                      user-template-create-keys-spec-req))
 
 (s/def ::schema-create
   (su/only-keys-maps user-template/create-keys-spec
-                     {:opt-un [::userTemplate]}))
+                     {:opt-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_template_github.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_template_github.cljc
@@ -15,12 +15,11 @@
 
 
 ;; Defines the contents of the github-registration template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
-(s/def ::userTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      user-template-github-registration-keys-href))
 
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::userTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_template_mitreid.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_template_mitreid.cljc
@@ -15,12 +15,11 @@
 
 
 ;; Defines the contents of the mitreid-registration template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
-(s/def ::userTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      user-template-mitreid-registration-keys-href))
 
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::userTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_template_oidc.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_template_oidc.cljc
@@ -15,12 +15,11 @@
 
 
 ;; Defines the contents of the oidc-registration template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
-(s/def ::userTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      user-template-oidc-registration-keys-href))
 
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::userTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/spec/user_template_self_registration.cljc
+++ b/cimi/src/sixsq/nuvla/server/resources/spec/user_template_self_registration.cljc
@@ -65,12 +65,11 @@
                      user-template-self-registration-keys))
 
 ;; Defines the contents of the self-registration template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :userTemplate here.
-(s/def ::userTemplate
+(s/def ::template
   (su/only-keys-maps ps/template-keys-spec
                      user-template-self-registration-keys
                      user-template-self-registration-keys-href))
 
 (s/def ::schema-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [::userTemplate]}))
+                     {:req-un [::template]}))

--- a/cimi/src/sixsq/nuvla/server/resources/user.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/user.clj
@@ -65,7 +65,7 @@ requires a template. All the SCRUD actions follow the standard CIMI patterns.
 ;; different create (registration) requests may take different inputs
 ;;
 (defn dispatch-on-registration-method [resource]
-  (get-in resource [:userTemplate :method]))
+  (get-in resource [:template :method]))
 
 (defmulti create-validate-subtype dispatch-on-registration-method)
 
@@ -179,16 +179,16 @@ requires a template. All the SCRUD actions follow the standard CIMI patterns.
 
   (try
     (let [idmap {:identity (:identity request)}
-          body (if (u/is-form? headers) (u/convert-form :userTemplate form-params) body)
-          authn-method (-> body :userTemplate :method)
+          body (if (u/is-form? headers) (u/convert-form :template form-params) body)
+          authn-method (-> body :template :method)
           desc-attrs (u/select-desc-keys body)
           [resp-fragment {:keys [id] :as body}] (-> body
                                                     (assoc :resourceURI create-uri)
-                                                    (update-in [:userTemplate] dissoc :method :id) ;; forces use of template reference
+                                                    (update-in [:template] dissoc :method :id) ;; forces use of template reference
                                                     (std-crud/resolve-hrefs idmap true)
-                                                    (update-in [:userTemplate] merge desc-attrs) ;; validate desc attrs
+                                                    (update-in [:template] merge desc-attrs) ;; validate desc attrs
                                                     (crud/validate)
-                                                    (:userTemplate)
+                                                    (:template)
                                                     (merge-with-defaults)
                                                     (tpl->user request) ;; returns a tuple [response-fragment, resource-body]
                                                     (merge desc-attrs)
@@ -212,7 +212,7 @@ requires a template. All the SCRUD actions follow the standard CIMI patterns.
                   (post-user-add (assoc body :id resource-id) request))
                 result)))
     (catch Exception e
-      (let [redirectURI (get-in body [:userTemplate :redirectURI])
+      (let [redirectURI (get-in body [:template :redirectURI])
             {:keys [status] :as http-response} (ex-data e)]
         (if (and redirectURI (= 400 status))
           (throw (r/ex-redirect (str "invalid parameter values provided") nil redirectURI))

--- a/cimi/src/sixsq/nuvla/server/resources/user_auto.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/user_auto.clj
@@ -18,7 +18,7 @@
 
 (def create-validate-fn (u/create-spec-validation-fn ::ut-auto/schema-create))
 (defmethod p/create-validate-subtype user-template/registration-method
-  [{resource :userTemplate :as create-document}]
+  [{resource :template :as create-document}]
   (user-utils/check-password-constraints resource)
   (create-validate-fn create-document))
 

--- a/cimi/src/sixsq/nuvla/server/resources/user_oidc.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/user_oidc.clj
@@ -14,7 +14,7 @@
 
 (def create-validate-fn (u/create-spec-validation-fn ::ut-oidc/schema-create))
 (defmethod p/create-validate-subtype user-template/registration-method
-  [{resource :userTemplate :as create-document}]
+  [{resource :template :as create-document}]
   (create-validate-fn create-document))
 
 

--- a/cimi/src/sixsq/nuvla/server/resources/user_params.clj
+++ b/cimi/src/sixsq/nuvla/server/resources/user_params.clj
@@ -73,7 +73,7 @@ where the value is the `id` of the User resource without the 'user/' prefix.
 ;;
 
 (defn dispatch-on-cloud-service-type [resource]
-  (get-in resource [:userParamTemplate :paramsType]))
+  (get-in resource [:template :paramsType]))
 
 (defmulti create-validate-subtype dispatch-on-cloud-service-type)
 
@@ -134,7 +134,7 @@ where the value is the `id` of the User resource without the 'user/' prefix.
 (defn conflict-if-exists
   "Only one :paramsType document is allowed per user."
   [request]
-  (let [params-type (get-in request [:body :userParamTemplate :paramsType])
+  (let [params-type (get-in request [:body :template :paramsType])
         cimi-filter (cpi/cimi-filter {"filter" (format "paramsType='%s'" params-type)})
         req (update-in request [:cimi-params] #(assoc % :filter cimi-filter))
         resp (crud/query req)
@@ -156,7 +156,7 @@ where the value is the `id` of the User resource without the 'user/' prefix.
         body (-> body
                  (assoc :resourceURI create-uri)
                  (crud/validate)
-                 (:userParamTemplate)
+                 :template
                  (tpl->user-params request))]
     (add-impl (assoc request :body body))))
 

--- a/cimi/test/sixsq/nuvla/auth/test_helper.clj
+++ b/cimi/test/sixsq/nuvla/auth/test_helper.clj
@@ -20,7 +20,7 @@
 (def req-u-role "ADMIN")
 
 
-(def req-template {:userTemplate
+(def req-template {:template
                    {:href   (str ct/resource-url "/" direct/registration-method)
                     :method "direct"}})
 
@@ -41,7 +41,7 @@
   [{:keys [password state] :as user}]
   (->> (assoc user :password (ia/hash-password password)
                    :state (or state "ACTIVE"))
-       (update-in request-base [:body :userTemplate] merge)))
+       (update-in request-base [:body :template] merge)))
 
 
 (defn add-user-for-test!

--- a/cimi/test/sixsq/nuvla/server/resources/configuration_lifecycle_test_utils.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/configuration_lifecycle_test_utils.clj
@@ -37,10 +37,10 @@
         valid-create {:name                  name-attr
                       :description           description-attr
                       :tags                  tags-attr
-                      :configurationTemplate (ltu/strip-unwanted-attrs (assoc template attr-kw attr-value))}
-        href-create {:configurationTemplate {:href   href
+                      :template (ltu/strip-unwanted-attrs (assoc template attr-kw attr-value))}
+        href-create {:template {:href   href
                                              attr-kw attr-value}}
-        invalid-create (assoc-in valid-create [:configurationTemplate :invalid] "BAD")]
+        invalid-create (assoc-in valid-create [:template :invalid] "BAD")]
 
     ;; anonymous create should fail
     (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/configuration_slipstream_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/configuration_slipstream_lifecycle_test.clj
@@ -35,7 +35,7 @@
                  (ltu/body->edn)
                  (ltu/is-status 200))
         template (get-in resp [:response :body])
-        valid-create {:configurationTemplate (ltu/strip-unwanted-attrs (assoc template attr-kw attr-value))}
+        valid-create {:template (ltu/strip-unwanted-attrs (assoc template attr-kw attr-value))}
 
         uri (str (u/de-camelcase resource-name) "/" service)
         abs-uri (str p/service-context uri)]

--- a/cimi/test/sixsq/nuvla/server/resources/connector_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/connector_lifecycle_test.clj
@@ -32,12 +32,12 @@
                  (ltu/body->edn)
                  (ltu/is-status 200))
         template (get-in resp [:response :body])
-        valid-create {:connectorTemplate (ltu/strip-unwanted-attrs (merge template {:alphaKey     2001
-                                                                                    :instanceName "alpha-omega"}))}
-        href-create {:connectorTemplate {:href         href
-                                         :alphaKey     3001
-                                         :instanceName "alpha-omega"}}
-        invalid-create (assoc-in valid-create [:connectorTemplate :invalid] "BAD")]
+        valid-create {:template (ltu/strip-unwanted-attrs (merge template {:alphaKey     2001
+                                                                           :instanceName "alpha-omega"}))}
+        href-create {:template {:href         href
+                                :alphaKey     3001
+                                :instanceName "alpha-omega"}}
+        invalid-create (assoc-in valid-create [:template :invalid] "BAD")]
 
     ;; anonymous create should fail
     (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/connector_template_alpha_example.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/connector_template_alpha_example.clj
@@ -26,15 +26,14 @@
                       :opt-un [:cimi.connector-template.alpha/objectStoreEndpoint]}))
 
 ;; Defines the contents of the alpha template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :connectorTemplate here.
-(s/def :cimi.connector-template.alpha/connectorTemplate
+(s/def :cimi.connector-template.alpha/template
   (su/only-keys-maps ps/template-keys-spec
                      {:opt-un [:cimi.connector-template.alpha/alphaKey
                                :cimi.connector-template.alpha/objectStoreEndpoint]}))
 
 (s/def :cimi/connector-template.alpha-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [:cimi.connector-template.alpha/connectorTemplate]}))
+                     {:opt-un [:cimi.connector-template.alpha/template]}))
 
 ;;
 ;; resource

--- a/cimi/test/sixsq/nuvla/server/resources/credential_api_key_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/credential_api_key_lifecycle_test.clj
@@ -43,18 +43,18 @@
                      (ltu/is-status 200)
                      (get-in [:response :body]))
 
-        create-import-no-href {:credentialTemplate (ltu/strip-unwanted-attrs template)}
+        create-import-no-href {:template (ltu/strip-unwanted-attrs template)}
 
-        create-import-href {:name               name-attr
-                            :description        description-attr
-                            :tags               tags-attr
-                            :credentialTemplate {:href href
-                                                 :ttl  1000}}
+        create-import-href {:name        name-attr
+                            :description description-attr
+                            :tags        tags-attr
+                            :template    {:href href
+                                          :ttl  1000}}
 
-        create-import-href-zero-ttl {:credentialTemplate {:href href
-                                                          :ttl  0}}
+        create-import-href-zero-ttl {:template {:href href
+                                                :ttl  0}}
 
-        create-import-href-no-ttl {:credentialTemplate {:href href}}]
+        create-import-href-no-ttl {:template {:href href}}]
 
     ;; admin/user query should succeed but be empty (no credentials created yet)
     (doseq [session [session-admin session-user]]

--- a/cimi/test/sixsq/nuvla/server/resources/credential_cloud_alpha.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/credential_cloud_alpha.clj
@@ -15,7 +15,7 @@
 
 (s/def :cimi/credential.cloud-alpha.create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [:cimi.credential-template.cloud-alpha/credentialTemplate]}))
+                     {:req-un [:cimi.credential-template.cloud-alpha/template]}))
 
 ;;
 ;; convert template to credential

--- a/cimi/test/sixsq/nuvla/server/resources/credential_ssh_public_key_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/credential_ssh_public_key_lifecycle_test.clj
@@ -38,14 +38,14 @@
 
         imported-ssh-key-info (ssh-utils/generate)
 
-        create-import-no-href {:credentialTemplate (ltu/strip-unwanted-attrs
-                                                     (assoc template
-                                                       :publicKey (:publicKey imported-ssh-key-info)))}
+        create-import-no-href {:template (ltu/strip-unwanted-attrs
+                                           (assoc template
+                                             :publicKey (:publicKey imported-ssh-key-info)))}
 
-        create-import-href {:credentialTemplate {:href      href
-                                                 :publicKey (:publicKey imported-ssh-key-info)}}
+        create-import-href {:template {:href      href
+                                       :publicKey (:publicKey imported-ssh-key-info)}}
 
-        invalid-create-href (assoc-in create-import-href [:credentialTemplate :href] "user-template/unknown-template")]
+        invalid-create-href (assoc-in create-import-href [:template :href] "user-template/unknown-template")]
 
     ;; admin/user query should succeed but be empty (no credentials created yet)
     (doseq [session [session-admin session-user]]
@@ -85,7 +85,7 @@
     (-> session-user
         (request base-uri
                  :request-method :post
-                 :body (json/write-str (assoc-in create-import-href [:credentialTemplate :publicKey] "bad-ssh-key")))
+                 :body (json/write-str (assoc-in create-import-href [:template :publicKey] "bad-ssh-key")))
         (ltu/body->edn)
         (ltu/is-status 400)
         (ltu/message-matches #".*invalid public key.*"))
@@ -149,7 +149,7 @@
                      (ltu/is-status 200)
                      (get-in [:response :body]))
 
-        create-import-href {:credentialTemplate {:href href}}]
+        create-import-href {:template {:href href}}]
 
     ;; create a credential as a normal user
     (let [resp (-> session-user

--- a/cimi/test/sixsq/nuvla/server/resources/credential_template_cloud_alpha.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/credential_template_cloud_alpha.clj
@@ -24,15 +24,14 @@
                      ; credential-template-keys-spec))
 
 ;; Defines the contents of the cloud-alpha template used in a create resource.
-;; NOTE: The name must match the key defined by the resource, :credentialTemplate here.
-(s/def :cimi.credential-template.cloud-alpha/credentialTemplate
+(s/def :cimi.credential-template.cloud-alpha/template
   (su/only-keys-maps ps/template-keys-spec
                      ctc/credential-template-create-keys-spec))
                      ;credential-template-create-keys-spec))
 
 (s/def :cimi/credential-template.cloud-alpha-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:req-un [:cimi.credential-template.cloud-alpha/credentialTemplate]}))
+                     {:req-un [:cimi.credential-template.cloud-alpha/template]}))
 
 ;; Template.
 (def ^:const credential-type (str "cloud-cred-" ct/cloud-service-type))

--- a/cimi/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
@@ -41,8 +41,8 @@
                                     (ltu/body->edn)
                                     (ltu/is-status 201)
                                     (ltu/location))
-        valid-deployment {:deploymentTemplate {:href deployment-template-uri} :name "dep1" :description "dep1 desc"}
-        valid-deployment-from-module {:deploymentTemplate {:module {:href module-uri}}}]
+        valid-deployment {:template {:href deployment-template-uri} :name "dep1" :description "dep1 desc"}
+        valid-deployment-from-module {:template {:module {:href module-uri}}}]
 
     ;; anonymous create should fail
     (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
@@ -164,15 +164,15 @@
 (defn full-eo-lifecycle
   [template-url template-obj]
   (let [template (get-template template-url)
-        create-href {:externalObjectTemplate (-> template-obj
-                                                 (assoc :href (:id template))
-                                                 (dissoc :objectType))}
-        create-no-href {:externalObjectTemplate (merge (ltu/strip-unwanted-attrs template) template-obj)}]
+        create-href {:template (-> template-obj
+                                   (assoc :href (:id template))
+                                   (dissoc :objectType))}
+        create-no-href {:template (merge (ltu/strip-unwanted-attrs template) template-obj)}]
 
     ;; check with and without a href attribute
     (doseq [valid-create [create-href create-no-href]]
 
-      (let [invalid-create (assoc-in valid-create [:externalObjectTemplate :invalid] "BAD")]
+      (let [invalid-create (assoc-in valid-create [:template :invalid] "BAD")]
 
         ;; anonymous create should always return a 403 error
         (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
@@ -51,7 +51,7 @@
 
 (defn create-cloud-cred
   [user-session]
-  (let [cred-create {:credentialTemplate
+  (let [cred-create {:template
                      {:href      (str credt/resource-url "/" cred-alpha/method)
                       :key       "key"
                       :secret    "secret"

--- a/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/external_object_lifecycle_test_utils.clj
@@ -78,10 +78,10 @@
 
 (defn create-connector-fixture!
   [f]
-  (let [con-create {:connectorTemplate {:href                (str cont/resource-url "/" con-alpha/cloud-service-type)
-                                        :alphaKey            1234
-                                        :instanceName        connector-name
-                                        :objectStoreEndpoint obj-store-endpoint}}]
+  (let [con-create {:template {:href                (str cont/resource-url "/" con-alpha/cloud-service-type)
+                               :alphaKey            1234
+                               :instanceName        connector-name
+                               :objectStoreEndpoint obj-store-endpoint}}]
     (-> session-admin
         (request (str p/service-context (u/de-camelcase c/resource-name))
                  :request-method :post

--- a/cimi/test/sixsq/nuvla/server/resources/external_object_public_lifecycle_test.clj-FIXME
+++ b/cimi/test/sixsq/nuvla/server/resources/external_object_public_lifecycle_test.clj-FIXME
@@ -51,9 +51,9 @@
         session-user (header session-anon authn-info-header eoltu/user-info-header)
         base-uri (str p/service-context (u/de-camelcase eo/resource-name))
         template (eoltu/get-template (str p/service-context eot/resource-url "/" public/objectType))
-        create-href {:externalObjectTemplate (-> (external-object)
-                                                 (assoc :href (:id template))
-                                                 (dissoc :objectType))}]
+        create-href {:template (-> (external-object)
+                                   (assoc :href (:id template))
+                                   (dissoc :objectType))}]
 
     ;; Create the test object.
     (-> session-user

--- a/cimi/test/sixsq/nuvla/server/resources/external_object_template_alpha_example.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/external_object_template_alpha_example.clj
@@ -33,13 +33,13 @@
   (su/only-keys-maps resource-keys-spec))
 
 
-(s/def :cimi.external-object-template.alpha/externalObjectTemplate
+(s/def :cimi.external-object-template.alpha/template
   (su/only-keys-maps c/template-attrs
                      (u/remove-req external-object-alpha-keys-spec #{::eo/state})))
 
 (s/def :cimi/external-object-template.alpha-create
   (su/only-keys-maps c/create-attrs
-                     {:req-un [:cimi.external-object-template.alpha/externalObjectTemplate]}))
+                     {:req-un [:cimi.external-object-template.alpha/template]}))
 
 ;;
 ;; template resource
@@ -72,7 +72,7 @@
   [resource]
   (validate-fn resource))
 
-(def validate-fn (u/create-spec-validation-fn :cimi.external-object-template.alpha/externalObjectTemplate))
+(def validate-fn (u/create-spec-validation-fn :cimi.external-object-template.alpha/template))
 (defmethod eot/validate-subtype-template objectType
   [resource]
   (validate-fn resource))

--- a/cimi/test/sixsq/nuvla/server/resources/session_api_key_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_api_key_lifecycle_test.clj
@@ -127,15 +127,15 @@
             description-attr "description"
             tags-attr ["one", "two"]
 
-            valid-create {:name            name-attr
-                          :description     description-attr
-                          :tags            tags-attr
-                          :sessionTemplate {:href   href
-                                            :key    uuid
-                                            :secret secret}}
-            valid-create-redirect (assoc-in valid-create [:sessionTemplate :redirectURI] "http://redirect.example.org")
-            unauthorized-create (update-in valid-create [:sessionTemplate :secret] (constantly bad-digest))
-            invalid-create (assoc-in valid-create [:sessionTemplate :invalid] "BAD")]
+            valid-create {:name        name-attr
+                          :description description-attr
+                          :tags        tags-attr
+                          :template    {:href   href
+                                        :key    uuid
+                                        :secret secret}}
+            valid-create-redirect (assoc-in valid-create [:template :redirectURI] "http://redirect.example.org")
+            unauthorized-create (update-in valid-create [:template :secret] (constantly bad-digest))
+            invalid-create (assoc-in valid-create [:template :invalid] "BAD")]
 
         ;; anonymous query should succeed but have no entries
         (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/session_github_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_github_lifecycle_test.clj
@@ -40,9 +40,9 @@
                               :acl         st/resource-acl})
 
 (def configuration-session-github {:template {:service      "session-github"
-                                                           :instance     instance
-                                                           :clientID     "FAKE_CLIENT_ID"
-                                                           :clientSecret "ABCDEF..."}})
+                                              :instance     instance
+                                              :clientID     "FAKE_CLIENT_ID"
+                                              :clientSecret "ABCDEF..."}})
 
 ;; callback state reset between tests
 (defn reset-callback! [callback-id]
@@ -86,14 +86,14 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          href-create {:name            name-attr
-                       :description     description-attr
-                       :tags            tags-attr
-                       :sessionTemplate {:href href}}
-          href-create-redirect {:sessionTemplate {:href        href
-                                                  :redirectURI redirect-uri-example}}
-          invalid-create (assoc-in href-create [:sessionTemplate :invalid] "BAD")
-          invalid-create-redirect (assoc-in href-create-redirect [:sessionTemplate :invalid] "BAD")]
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri-example}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")
+          invalid-create-redirect (assoc-in href-create-redirect [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/session_github_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_github_lifecycle_test.clj
@@ -39,7 +39,7 @@
                               :description "External Authentication with GitHub Credentials"
                               :acl         st/resource-acl})
 
-(def configuration-session-github {:configurationTemplate {:service      "session-github"
+(def configuration-session-github {:template {:service      "session-github"
                                                            :instance     instance
                                                            :clientID     "FAKE_CLIENT_ID"
                                                            :clientSecret "ABCDEF..."}})

--- a/cimi/test/sixsq/nuvla/server/resources/session_internal_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_internal_lifecycle_test.clj
@@ -88,16 +88,16 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          valid-create {:name            name-attr
-                        :description     description-attr
-                        :tags            tags-attr
-                        :sessionTemplate {:href     href
-                                          :username "user"
-                                          :password "user"}}
-          valid-create-redirect (assoc-in valid-create [:sessionTemplate :redirectURI] "http://redirect.example.org")
-          unauthorized-create (update-in valid-create [:sessionTemplate :password] (constantly "BAD"))
-          invalid-create (assoc-in valid-create [:sessionTemplate :invalid] "BAD")
-          invalid-create-redirect (assoc-in valid-create-redirect [:sessionTemplate :invalid] "BAD")]
+          valid-create {:name        name-attr
+                        :description description-attr
+                        :tags        tags-attr
+                        :template    {:href     href
+                                      :username "user"
+                                      :password "user"}}
+          valid-create-redirect (assoc-in valid-create [:template :redirectURI] "http://redirect.example.org")
+          unauthorized-create (update-in valid-create [:template :password] (constantly "BAD"))
+          invalid-create (assoc-in valid-create [:template :invalid] "BAD")
+          invalid-create-redirect (assoc-in valid-create-redirect [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon
@@ -235,8 +235,8 @@
 
       ;; admin create must also succeed
       (let [create-req (-> valid-create
-                           (assoc-in [:sessionTemplate :username] "root")
-                           (assoc-in [:sessionTemplate :password] "root"))
+                           (assoc-in [:template :username] "root")
+                           (assoc-in [:template :password] "root"))
             resp (-> session-anon
                      (request base-uri
                               :request-method :post

--- a/cimi/test/sixsq/nuvla/server/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_mitreid_lifecycle_test.clj
@@ -52,7 +52,7 @@
     "3wIDAQAB"))
 
 (def configuration-session-mitreid
-  {:configurationTemplate {:service        "session-mitreid" ;;reusing configuration from session MITREid
+  {:template {:service        "session-mitreid" ;;reusing configuration from session MITREid
                            :instance       instance
                            :clientID       "FAKE_CLIENT_ID"
                            :clientSecret   "MyMITREidClientSecret"

--- a/cimi/test/sixsq/nuvla/server/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_mitreid_lifecycle_test.clj
@@ -52,14 +52,14 @@
     "3wIDAQAB"))
 
 (def configuration-session-mitreid
-  {:template {:service        "session-mitreid" ;;reusing configuration from session MITREid
-                           :instance       instance
-                           :clientID       "FAKE_CLIENT_ID"
-                           :clientSecret   "MyMITREidClientSecret"
-                           :authorizeURL   "https://authorize.mitreid.com/authorize"
-                           :tokenURL       "https://token.mitreid.com/token"
-                           :userProfileURL "https://userinfo.mitreid.com/api/user/me"
-                           :publicKey      auth-pubkey}})
+  {:template {:service        "session-mitreid"             ;;reusing configuration from session MITREid
+              :instance       instance
+              :clientID       "FAKE_CLIENT_ID"
+              :clientSecret   "MyMITREidClientSecret"
+              :authorizeURL   "https://authorize.mitreid.com/authorize"
+              :tokenURL       "https://token.mitreid.com/token"
+              :userProfileURL "https://userinfo.mitreid.com/api/user/me"
+              :publicKey      auth-pubkey}})
 
 
 (deftest lifecycle
@@ -99,15 +99,15 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          ;;valid-create {:sessionTemplate (ltu/strip-unwanted-attrs template)}
+          ;;valid-create {:template (ltu/strip-unwanted-attrs template)}
 
-          href-create {:name            name-attr
-                       :description     description-attr
-                       :tags            tags-attr
-                       :sessionTemplate {:href href}}
-          href-create-redirect {:sessionTemplate {:href        href
-                                                  :redirectURI redirect-uri}}
-          invalid-create (assoc-in href-create [:sessionTemplate :invalid] "BAD")]
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/session_mitreid_token_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_mitreid_token_lifecycle_test.clj
@@ -56,19 +56,19 @@
 
 (def configuration-session-mitreid
   {:template {:service        "session-mitreid"
-                           :instance       instance
-                           :clientID       "FAKE_CLIENT_ID"
-                           :clientSecret   "MyMITREidClientSecret"
-                           :authorizeURL   "https://authorize.mitreid.com/authorize"
-                           :tokenURL       "https://token.mitreid.com/token"
-                           :userProfileURL "https://userinfo.mitreid.com/api/user/me"
-                           :publicKey      auth-pubkey}})
+              :instance       instance
+              :clientID       "FAKE_CLIENT_ID"
+              :clientSecret   "MyMITREidClientSecret"
+              :authorizeURL   "https://authorize.mitreid.com/authorize"
+              :tokenURL       "https://token.mitreid.com/token"
+              :userProfileURL "https://userinfo.mitreid.com/api/user/me"
+              :publicKey      auth-pubkey}})
 
 
 (def configuration-session-mitreid-token
   {:template {:service   "session-mitreid-token"
-                           :instance  instance
-                           :clientIPs [valid-ip]}})
+              :instance  instance
+              :clientIPs [valid-ip]}})
 
 
 (deftest lifecycle
@@ -144,14 +144,14 @@
               description-attr "description"
               tags-attr ["one", "two"]
 
-              valid-create {:name            name-attr
-                            :description     description-attr
-                            :tags            tags-attr
-                            :sessionTemplate {:href  href
-                                              :token access-token}}
+              valid-create {:name        name-attr
+                            :description description-attr
+                            :tags        tags-attr
+                            :template    {:href  href
+                                          :token access-token}}
 
-              valid-create-redirect (assoc-in valid-create [:sessionTemplate :redirectURI] "http://redirect.example.org")
-              invalid-create (assoc-in valid-create [:sessionTemplate :invalid] "BAD")]
+              valid-create-redirect (assoc-in valid-create [:template :redirectURI] "http://redirect.example.org")
+              invalid-create (assoc-in valid-create [:template :invalid] "BAD")]
 
           ;; invalid create should return a 400
           (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/session_mitreid_token_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_mitreid_token_lifecycle_test.clj
@@ -55,7 +55,7 @@
 
 
 (def configuration-session-mitreid
-  {:configurationTemplate {:service        "session-mitreid"
+  {:template {:service        "session-mitreid"
                            :instance       instance
                            :clientID       "FAKE_CLIENT_ID"
                            :clientSecret   "MyMITREidClientSecret"
@@ -66,7 +66,7 @@
 
 
 (def configuration-session-mitreid-token
-  {:configurationTemplate {:service   "session-mitreid-token"
+  {:template {:service   "session-mitreid-token"
                            :instance  instance
                            :clientIPs [valid-ip]}})
 

--- a/cimi/test/sixsq/nuvla/server/resources/session_oidc_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_oidc_lifecycle_test.clj
@@ -52,12 +52,12 @@
     "3wIDAQAB"))
 
 (def configuration-session-oidc {:template {:service      "session-oidc"
-                                                         :instance     instance
-                                                         :clientID     "FAKE_CLIENT_ID"
-                                                         :clientSecret "MyOIDCClientSecret"
-                                                         :authorizeURL "https://authorize.oidc.com/authorize"
-                                                         :tokenURL     "https://token.oidc.com/token"
-                                                         :publicKey    auth-pubkey}})
+                                            :instance     instance
+                                            :clientID     "FAKE_CLIENT_ID"
+                                            :clientSecret "MyOIDCClientSecret"
+                                            :authorizeURL "https://authorize.oidc.com/authorize"
+                                            :tokenURL     "https://token.oidc.com/token"
+                                            :publicKey    auth-pubkey}})
 
 (deftest lifecycle
 
@@ -97,15 +97,15 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          ;;valid-create {:sessionTemplate (ltu/strip-unwanted-attrs template)}
-          href-create {:name            name-attr
-                       :description     description-attr
-                       :tags            tags-attr
-                       :sessionTemplate {:href href}}
+          ;;valid-create {:template (ltu/strip-unwanted-attrs template)}
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
 
-          href-create-redirect {:sessionTemplate {:href        href
-                                                  :redirectURI redirect-uri}}
-          invalid-create (assoc-in href-create [:sessionTemplate :invalid] "BAD")]
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/session_oidc_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_oidc_lifecycle_test.clj
@@ -51,7 +51,7 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-session-oidc {:configurationTemplate {:service      "session-oidc"
+(def configuration-session-oidc {:template {:service      "session-oidc"
                                                          :instance     instance
                                                          :clientID     "FAKE_CLIENT_ID"
                                                          :clientSecret "MyOIDCClientSecret"

--- a/cimi/test/sixsq/nuvla/server/resources/session_template_internal_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_template_internal_lifecycle_test.clj
@@ -77,7 +77,7 @@
                         (ltu/body->edn)
                         (ltu/is-status 200)
                         (ltu/is-resource-uri st/collection-uri)
-                        (ltu/entries :sessionTemplates))]
+                        (ltu/entries :templates))]
         (is (zero? (count (filter #(= method (:method %)) entries))))))))
 
 

--- a/cimi/test/sixsq/nuvla/server/resources/session_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/session_test.clj
@@ -21,5 +21,5 @@
                            false? {"content-type" "application/json"}))
 
 (deftest check-convert-form
-  (is (= {:sessionTemplate {:alpha "alpha", :beta "beta"}}
-         (u/convert-form :sessionTemplate {:alpha "alpha", "beta" "beta"}))))
+  (is (= {:template {:alpha "alpha", :beta "beta"}}
+         (u/convert-form :template {:alpha "alpha", "beta" "beta"}))))

--- a/cimi/test/sixsq/nuvla/server/resources/spec/deployment_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/deployment_test.cljc
@@ -35,28 +35,28 @@
                                   :disk       300}]})
 
 
-(def valid-deployment {:id                 (str d/resource-url "/connector-uuid")
-                       :resourceURI        d/resource-uri
-                       :created            timestamp
-                       :updated            timestamp
-                       :acl                valid-acl
+(def valid-deployment {:id               (str d/resource-url "/connector-uuid")
+                       :resourceURI      d/resource-uri
+                       :created          timestamp
+                       :updated          timestamp
+                       :acl              valid-acl
 
-                       :state              "STARTED"
+                       :state            "STARTED"
 
-                       :clientAPIKey       {:href   "credential/uuid"
-                                            :secret "api secret"}
+                       :clientAPIKey     {:href   "credential/uuid"
+                                          :secret "api secret"}
 
-                       :deploymentTemplate {:href "deployment-template/uuid-1"}
+                       :template         {:href "deployment-template/uuid-1"}
 
-                       :sshPublicKeys      ["ssh-rsa key1..." "ssh-rsa key2..."]
+                       :sshPublicKeys    ["ssh-rsa key1..." "ssh-rsa key2..."]
 
-                       :outputParameters   [{:parameter "param-1"}]
-                       :module             (merge {:href "my-module-uuid"} valid-module)
+                       :outputParameters [{:parameter "param-1"}]
+                       :module           (merge {:href "my-module-uuid"} valid-module)
 
-                       :externalObjects    ["external-object/uuid1" "external-object/uuid2"]
-                       :serviceOffers      {:service-offer/uuid1 ["service-offer/dataset1" "service-offer/dataset2"]
-                                            :service-offer/uuid2 nil
-                                            :service-offer/uuid3 ["service-offer/dataset3"]}})
+                       :externalObjects  ["external-object/uuid1" "external-object/uuid2"]
+                       :serviceOffers    {:service-offer/uuid1 ["service-offer/dataset1" "service-offer/dataset2"]
+                                          :service-offer/uuid2 nil
+                                          :service-offer/uuid3 ["service-offer/dataset3"]}})
 
 
 (deftest test-schema-check
@@ -73,5 +73,5 @@
     (stu/is-invalid ::ds/deployment (dissoc valid-deployment k)))
 
   ;; optional attributes
-  (doseq [k #{:deploymentTemplate :sshPublicKeys :externalObjects :serviceOffers}]
+  (doseq [k #{:template :sshPublicKeys :externalObjects :serviceOffers}]
     (stu/is-valid ::ds/deployment (dissoc valid-deployment k))))

--- a/cimi/test/sixsq/nuvla/server/resources/spec/external_object_template_generic_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/external_object_template_generic_test.cljc
@@ -11,17 +11,17 @@
   (let [root (merge tpl/resource
                     {:href "external-object-template/generic"})]
 
-    (stu/is-valid ::eot-generic/externalObjectTemplate root)
+    (stu/is-valid ::eot-generic/template root)
 
     ;; mandatory keywords
     (doseq [k #{:objectType :objectStoreCred :bucketName :objectName}]
-      (stu/is-invalid ::eot-generic/externalObjectTemplate (dissoc root k)))
+      (stu/is-invalid ::eot-generic/template (dissoc root k)))
 
     ;; optional keywords
     (doseq [k #{:contentType :href}]
-      (stu/is-valid ::eot-generic/externalObjectTemplate (dissoc root k)))
+      (stu/is-valid ::eot-generic/template (dissoc root k)))
 
 
     (let [create {:resourceURI            (str eot/resource-uri "Create")
-                  :externalObjectTemplate (dissoc root :id)}]
+                  :template (dissoc root :id)}]
       (stu/is-valid ::eot-generic/external-object-create create))))

--- a/cimi/test/sixsq/nuvla/server/resources/spec/session_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/session_test.cljc
@@ -24,11 +24,11 @@
              :server          "nuv.la"
              :clientIP        "127.0.0.1"
              :redirectURI     "https://nuv.la/webui/profile"
-             :sessionTemplate {:href "session-template/internal"}}]
+             :template {:href "session-template/internal"}}]
 
     (stu/is-valid ::session/session cfg)
 
-    (doseq [attr #{:id :resourceURI :created :updated :acl :method :expiry :sessionTemplate}]
+    (doseq [attr #{:id :resourceURI :created :updated :acl :method :expiry :template}]
       (stu/is-invalid ::session/session (dissoc cfg attr)))
 
     (doseq [attr #{:username :server :clientIP}]

--- a/cimi/test/sixsq/nuvla/server/resources/spec/user_template_github_registration_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/user_template_github_registration_test.cljc
@@ -28,11 +28,11 @@
              :method      "github-registration"
              :instance    "github-registration"}
 
-        create-tpl {:name         "my-create"
-                    :description  "my create description"
-                    :tags         #{"3", "4"}
-                    :resourceURI  "http://sixsq.com/slipstream/1/UserTemplateCreate"
-                    :userTemplate (dissoc tpl :id)}]
+        create-tpl {:name        "my-create"
+                    :description "my create description"
+                    :tags        #{"3", "4"}
+                    :resourceURI "http://sixsq.com/slipstream/1/UserTemplateCreate"
+                    :template    (dissoc tpl :id)}]
 
     ;; check the registration schema (without href)
     (stu/is-valid ::ut-github/schema tpl)
@@ -45,10 +45,10 @@
 
     ;; check the create template schema (with href)
     (stu/is-valid ::ut-github/schema-create create-tpl)
-    (stu/is-valid ::ut-github/schema-create (assoc-in create-tpl [:userTemplate :href] "user-template/abc"))
-    (stu/is-invalid ::ut-github/schema-create (assoc-in create-tpl [:userTemplate :href] "bad-reference/abc"))
+    (stu/is-valid ::ut-github/schema-create (assoc-in create-tpl [:template :href] "user-template/abc"))
+    (stu/is-invalid ::ut-github/schema-create (assoc-in create-tpl [:template :href] "bad-reference/abc"))
 
-    (doseq [attr #{:resourceURI :userTemplate}]
+    (doseq [attr #{:resourceURI :template}]
       (stu/is-invalid ::ut-github/schema-create (dissoc create-tpl attr)))
 
     (doseq [attr #{:name :description :group :tags}]

--- a/cimi/test/sixsq/nuvla/server/resources/spec/user_template_mitreid_registration_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/user_template_mitreid_registration_test.cljc
@@ -28,11 +28,11 @@
              :method      "mitreid-registration"
              :instance    "mitreid-registration"}
 
-        create-tpl {:name         "my-create"
-                    :description  "my create description"
-                    :tags         #{"3", "4"}
-                    :resourceURI  "http://sixsq.com/slipstream/1/UserTemplateCreate"
-                    :userTemplate (dissoc tpl :id)}]
+        create-tpl {:name        "my-create"
+                    :description "my create description"
+                    :tags        #{"3", "4"}
+                    :resourceURI "http://sixsq.com/slipstream/1/UserTemplateCreate"
+                    :template    (dissoc tpl :id)}]
 
     ;; check the registration schema (without href)
     (stu/is-valid ::ut-mitreid/schema tpl)
@@ -45,10 +45,10 @@
 
     ;; check the create template schema (with href)
     (stu/is-valid ::ut-mitreid/schema-create create-tpl)
-    (stu/is-valid ::ut-mitreid/schema-create (assoc-in create-tpl [:userTemplate :href] "user-template/abc"))
-    (stu/is-invalid ::ut-mitreid/schema-create (assoc-in create-tpl [:userTemplate :href] "bad-reference/abc"))
+    (stu/is-valid ::ut-mitreid/schema-create (assoc-in create-tpl [:template :href] "user-template/abc"))
+    (stu/is-invalid ::ut-mitreid/schema-create (assoc-in create-tpl [:template :href] "bad-reference/abc"))
 
-    (doseq [attr #{:resourceURI :userTemplate}]
+    (doseq [attr #{:resourceURI :template}]
       (stu/is-invalid ::ut-mitreid/schema-create (dissoc create-tpl attr)))
 
     (doseq [attr #{:name :description :group :tags}]

--- a/cimi/test/sixsq/nuvla/server/resources/spec/user_template_oidc_registration_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/user_template_oidc_registration_test.cljc
@@ -28,11 +28,11 @@
              :method      "oidc-registration"
              :instance    "oidc-registration"}
 
-        create-tpl {:name         "my-create"
-                    :description  "my create description"
-                    :tags         #{"3", "4"}
-                    :resourceURI  "http://sixsq.com/slipstream/1/UserTemplateCreate"
-                    :userTemplate (dissoc tpl :id)}]
+        create-tpl {:name        "my-create"
+                    :description "my create description"
+                    :tags        #{"3", "4"}
+                    :resourceURI "http://sixsq.com/slipstream/1/UserTemplateCreate"
+                    :template    (dissoc tpl :id)}]
 
     ;; check the registration schema (without href)
     (stu/is-valid ::ut-oidc/schema tpl)
@@ -45,10 +45,10 @@
 
     ;; check the create template schema (with href)
     (stu/is-valid ::ut-oidc/schema-create create-tpl)
-    (stu/is-valid ::ut-oidc/schema-create (assoc-in create-tpl [:userTemplate :href] "user-template/abc"))
-    (stu/is-invalid ::ut-oidc/schema-create (assoc-in create-tpl [:userTemplate :href] "bad-reference/abc"))
+    (stu/is-valid ::ut-oidc/schema-create (assoc-in create-tpl [:template :href] "user-template/abc"))
+    (stu/is-invalid ::ut-oidc/schema-create (assoc-in create-tpl [:template :href] "bad-reference/abc"))
 
-    (doseq [attr #{:resourceURI :userTemplate}]
+    (doseq [attr #{:resourceURI :template}]
       (stu/is-invalid ::ut-oidc/schema-create (dissoc create-tpl attr)))
 
     (doseq [attr #{:name :description :tags}]

--- a/cimi/test/sixsq/nuvla/server/resources/spec/user_template_self_registration_test.cljc
+++ b/cimi/test/sixsq/nuvla/server/resources/spec/user_template_self_registration_test.cljc
@@ -31,11 +31,11 @@
              :passwordRepeat "plaintext-password"
              :emailAddress   "someone@example.org"}
 
-        create-tpl {:name         "my-create"
-                    :description  "my create description"
-                    :tags         #{"3", "4"}
-                    :resourceURI  "http://sixsq.com/slipstream/1/UserTemplateCreate"
-                    :userTemplate (dissoc tpl :id)}]
+        create-tpl {:name        "my-create"
+                    :description "my create description"
+                    :tags        #{"3", "4"}
+                    :resourceURI "http://sixsq.com/slipstream/1/UserTemplateCreate"
+                    :template    (dissoc tpl :id)}]
 
     ;; check the registration schema (without href)
     (stu/is-valid ::ut-auto/schema tpl)
@@ -49,10 +49,10 @@
 
     ;; check the create template schema (with href)
     (stu/is-valid ::ut-auto/schema-create create-tpl)
-    (stu/is-valid ::ut-auto/schema-create (assoc-in create-tpl [:userTemplate :href] "user-template/abc"))
-    (stu/is-invalid ::ut-auto/schema-create (assoc-in create-tpl [:userTemplate :href] "bad-reference/abc"))
+    (stu/is-valid ::ut-auto/schema-create (assoc-in create-tpl [:template :href] "user-template/abc"))
+    (stu/is-invalid ::ut-auto/schema-create (assoc-in create-tpl [:template :href] "bad-reference/abc"))
 
-    (doseq [attr #{:resourceURI :userTemplate}]
+    (doseq [attr #{:resourceURI :template}]
       (stu/is-invalid ::ut-auto/schema-create (dissoc create-tpl attr)))
 
     (doseq [attr #{:name :description :tags}]

--- a/cimi/test/sixsq/nuvla/server/resources/user_params_exec_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_params_exec_lifecycle_test.clj
@@ -35,7 +35,7 @@
                      (ltu/body->edn)
                      (ltu/is-status 200)
                      (get-in [:response :body]))
-        create-from-templ {:userParamTemplate
+        create-from-templ {:template
                            (-> template
                                ltu/strip-unwanted-attrs
                                (merge {:defaultCloudService "foo-bar-baz"

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_direct_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_direct_lifecycle_test.clj
@@ -42,13 +42,13 @@
                      (ltu/is-status 200)
                      (get-in [:response :body]))
 
-        no-href-create {:userTemplate (ltu/strip-unwanted-attrs (assoc template
-                                                                  :username uname
-                                                                  :emailAddress "user@example.org"))}
-        href-create {:userTemplate {:href         href
-                                    :username     uname
-                                    :emailAddress "user@example.org"}}
-        invalid-create (assoc-in href-create [:userTemplate :href] "user-template/unknown-template")]
+        no-href-create {:template (ltu/strip-unwanted-attrs (assoc template
+                                                              :username uname
+                                                              :emailAddress "user@example.org"))}
+        href-create {:template {:href         href
+                                :username     uname
+                                :emailAddress "user@example.org"}}
+        invalid-create (assoc-in href-create [:template :href] "user-template/unknown-template")]
 
     ;; anonymous user collection query should succeed but be empty
     ;; access needed to allow self-registration
@@ -104,9 +104,9 @@
         (ltu/is-status 404))
 
     ;; create a user via admin
-    (let [create-req {:userTemplate {:href         href
-                                     :username     uname
-                                     :emailAddress "jane@example.org"}}
+    (let [create-req {:template {:href         href
+                                 :username     uname
+                                 :emailAddress "jane@example.org"}}
           resp (-> session-admin
                    (request base-uri
                             :request-method :post

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_github_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_github_lifecycle_test.clj
@@ -34,7 +34,7 @@
   (cbu/update-callback-state! "WAITING" callback-id))
 
 
-(def configuration-user-github {:configurationTemplate {:service      "session-github" ;;reusing configuration from session GitHub
+(def configuration-user-github {:template {:service      "session-github" ;;reusing configuration from session GitHub
                                                         :instance     github/registration-method
                                                         :clientID     "FAKE_CLIENT_ID"
                                                         :clientSecret "ABCDEF..."}})

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_github_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_github_lifecycle_test.clj
@@ -35,9 +35,9 @@
 
 
 (def configuration-user-github {:template {:service      "session-github" ;;reusing configuration from session GitHub
-                                                        :instance     github/registration-method
-                                                        :clientID     "FAKE_CLIENT_ID"
-                                                        :clientSecret "ABCDEF..."}})
+                                           :instance     github/registration-method
+                                           :clientID     "FAKE_CLIENT_ID"
+                                           :clientSecret "ABCDEF..."}})
 
 
 (deftest check-metadata
@@ -85,14 +85,14 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          href-create {:name         name-attr
-                       :description  description-attr
-                       :tags         tags-attr
-                       :userTemplate {:href href}}
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
 
-          href-create-redirect {:userTemplate {:href        href
-                                               :redirectURI redirect-uri-example}}
-          invalid-create (assoc-in href-create [:userTemplate :invalid] "BAD")]
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri-example}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")]
 
       ;; queries by anyone should succeed but have no entries
       (doseq [session [session-anon session-user session-admin]]

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_mitreid_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_mitreid_lifecycle_test.clj
@@ -44,7 +44,7 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-user-mitreid {:configurationTemplate {:service        "session-mitreid" ;;reusing configuration from session MITREid
+(def configuration-user-mitreid {:template {:service        "session-mitreid" ;;reusing configuration from session MITREid
                                                          :instance       mitreid/registration-method
                                                          :clientID       "FAKE_CLIENT_ID"
                                                          :clientSecret   "MyMITREidClientSecret"

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_mitreid_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_mitreid_lifecycle_test.clj
@@ -45,13 +45,13 @@
     "3wIDAQAB"))
 
 (def configuration-user-mitreid {:template {:service        "session-mitreid" ;;reusing configuration from session MITREid
-                                                         :instance       mitreid/registration-method
-                                                         :clientID       "FAKE_CLIENT_ID"
-                                                         :clientSecret   "MyMITREidClientSecret"
-                                                         :authorizeURL   "https://authorize.mitreid.com/authorize"
-                                                         :tokenURL       "https://token.mitreid.com/token"
-                                                         :userProfileURL "https://userinfo.mitreid.com/api/user/me"
-                                                         :publicKey      auth-pubkey}})
+                                            :instance       mitreid/registration-method
+                                            :clientID       "FAKE_CLIENT_ID"
+                                            :clientSecret   "MyMITREidClientSecret"
+                                            :authorizeURL   "https://authorize.mitreid.com/authorize"
+                                            :tokenURL       "https://token.mitreid.com/token"
+                                            :userProfileURL "https://userinfo.mitreid.com/api/user/me"
+                                            :publicKey      auth-pubkey}})
 
 
 (deftest check-metadata
@@ -105,13 +105,13 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          href-create {:name         name-attr
-                       :description  description-attr
-                       :tags         tags-attr
-                       :userTemplate {:href href}}
-          href-create-redirect {:userTemplate {:href        href
-                                               :redirectURI redirect-uri}}
-          invalid-create (assoc-in href-create [:userTemplate :invalid] "BAD")]
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_oidc_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_oidc_lifecycle_test.clj
@@ -44,12 +44,12 @@
     "3wIDAQAB"))
 
 (def configuration-user-oidc {:template {:service      "session-oidc" ;;reusing configuration from session
-                                                      :instance     oidc/registration-method
-                                                      :clientID     "FAKE_CLIENT_ID"
-                                                      :clientSecret "MyClientSecret"
-                                                      :authorizeURL "https://authorize.oidc.com/authorize"
-                                                      :tokenURL     "https://token.oidc.com/token"
-                                                      :publicKey    auth-pubkey}})
+                                         :instance     oidc/registration-method
+                                         :clientID     "FAKE_CLIENT_ID"
+                                         :clientSecret "MyClientSecret"
+                                         :authorizeURL "https://authorize.oidc.com/authorize"
+                                         :tokenURL     "https://token.oidc.com/token"
+                                         :publicKey    auth-pubkey}})
 
 
 (deftest check-metadata
@@ -103,13 +103,13 @@
           description-attr "description"
           tags-attr ["one", "two"]
 
-          href-create {:name         name-attr
-                       :description  description-attr
-                       :tags         tags-attr
-                       :userTemplate {:href href}}
-          href-create-redirect {:userTemplate {:href        href
-                                               :redirectURI redirect-uri}}
-          invalid-create (assoc-in href-create [:userTemplate :invalid] "BAD")]
+          href-create {:name        name-attr
+                       :description description-attr
+                       :tags        tags-attr
+                       :template    {:href href}}
+          href-create-redirect {:template {:href        href
+                                           :redirectURI redirect-uri}}
+          invalid-create (assoc-in href-create [:template :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
       (-> session-anon

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_oidc_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_oidc_lifecycle_test.clj
@@ -43,7 +43,7 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-user-oidc {:configurationTemplate {:service      "session-oidc" ;;reusing configuration from session
+(def configuration-user-oidc {:template {:service      "session-oidc" ;;reusing configuration from session
                                                       :instance     oidc/registration-method
                                                       :clientID     "FAKE_CLIENT_ID"
                                                       :clientSecret "MyClientSecret"

--- a/cimi/test/sixsq/nuvla/server/resources/user_template_self_registration_lifecycle_test.clj
+++ b/cimi/test/sixsq/nuvla/server/resources/user_template_self_registration_lifecycle_test.clj
@@ -87,28 +87,28 @@
               tags-attr ["one", "two"]
               plaintext-password "plaintext-password"
 
-              no-href-create {:userTemplate (ltu/strip-unwanted-attrs (assoc template
-                                                                        :username uname
-                                                                        :password plaintext-password
-                                                                        :passwordRepeat plaintext-password
-                                                                        :emailAddress "user@example.org"))}
-              href-create {:name         name-attr
-                           :description  description-attr
-                           :tags         tags-attr
-                           :userTemplate {:href           href
-                                          :username       uname
-                                          :password       plaintext-password
-                                          :passwordRepeat plaintext-password
-                                          :emailAddress   "jane@example.org"}}
+              no-href-create {:template (ltu/strip-unwanted-attrs (assoc template
+                                                                    :username uname
+                                                                    :password plaintext-password
+                                                                    :passwordRepeat plaintext-password
+                                                                    :emailAddress "user@example.org"))}
+              href-create {:name        name-attr
+                           :description description-attr
+                           :tags        tags-attr
+                           :template    {:href           href
+                                         :username       uname
+                                         :password       plaintext-password
+                                         :passwordRepeat plaintext-password
+                                         :emailAddress   "jane@example.org"}}
 
-              href-create-alt (assoc-in href-create [:userTemplate :username] uname-alt)
+              href-create-alt (assoc-in href-create [:template :username] uname-alt)
 
-              href-create-redirect (assoc-in href-create-alt [:userTemplate :redirectURI] "http://redirect.example.org")
+              href-create-redirect (assoc-in href-create-alt [:template :redirectURI] "http://redirect.example.org")
 
-              invalid-create (assoc-in href-create [:userTemplate :href] "user-template/unknown-template")
+              invalid-create (assoc-in href-create [:template :href] "user-template/unknown-template")
 
-              bad-params-create (assoc-in href-create [:userTemplate :invalid] "BAD")
-              bad-params-create-redirect (assoc-in href-create-redirect [:userTemplate :invalid] "BAD")]
+              bad-params-create (assoc-in href-create [:template :invalid] "BAD")
+              bad-params-create-redirect (assoc-in href-create-redirect [:template :invalid] "BAD")]
 
 
           ;; user collection query should succeed but be empty for all users


### PR DESCRIPTION
Use the `:template` attribute in all create requests rather than resource dependent names (e.g. `:sessionTemplate`). 